### PR TITLE
Java driver benchmarks

### DIFF
--- a/benchmarks/basic/java-driver-3.x-async/Dockerfile
+++ b/benchmarks/basic/java-driver-3.x-async/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+RUN apt update
+
+# Install java 8
+RUN apt install -y openjdk-8-jdk
+RUN apt install -y maven
+#RUN update-alternatives --set java /usr/lib/jvm/jdk1.8.0_version/bin/java
+RUN export JAVA_HOME=/usr/lib/jvm/jdk1.8.0_version
+
+# Copy benchmark code into the container
+COPY source /source
+WORKDIR /source
+
+# Compile the code
+RUN mvn clean package

--- a/benchmarks/basic/java-driver-3.x-async/build.sh
+++ b/benchmarks/basic/java-driver-3.x-async/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build . -t rust-driver-benchmarks-basic-java-driver-3.x-async

--- a/benchmarks/basic/java-driver-3.x-async/run.sh
+++ b/benchmarks/basic/java-driver-3.x-async/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker run --rm -it --network host rust-driver-benchmarks-basic-java-driver-3.x-async \
+java -cp /source/target/source-1.0-SNAPSHOT.jar MainClass "$@"

--- a/benchmarks/basic/java-driver-3.x-async/source/pom.xml
+++ b/benchmarks/basic/java-driver-3.x-async/source/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>source</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.5.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.scylladb</groupId>
+            <artifactId>scylla-driver-core</artifactId>
+            <version>3.11.2.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+
+</project>

--- a/benchmarks/basic/java-driver-3.x-async/source/src/main/java/Config.java
+++ b/benchmarks/basic/java-driver-3.x-async/source/src/main/java/Config.java
@@ -1,0 +1,85 @@
+import java.util.Arrays;
+
+import org.apache.commons.cli.*;
+class Config{
+
+    enum Workload {
+        Inserts,
+        Selects,
+        Mixed,
+    };
+
+    String[] node_addresses;
+    Workload workload;
+    long tasks;
+    long concurrency;
+    boolean dont_prepare;
+    int threads;
+
+    Config(String[] args)  {
+
+        this.node_addresses = new String[]{"127.0.0.1"};
+        this.workload = Workload.Inserts;
+        this.tasks = 1000 * 1000;
+        this.concurrency = 1024;
+        this.dont_prepare = false;
+        this.threads = Runtime.getRuntime().availableProcessors();
+
+        Options options = new Options();
+
+        options.addOption("d", "dont-prepare", false, "Don't create tables and insert into them before the benchmark");
+        options.addOption("n", "nodes", true, "Addresses of database nodes to connect to separated by a comma");
+        options.addOption("w", "workload", true, "Type of work to perform (Inserts, Selects, Mixed)");
+        options.addOption("t", "tasks", true, "Total number of tasks (requests) to perform the during benchmark. In case of mixed workload there will be tasks inserts and tasks selects");
+        options.addOption("c", "concurrency", true, "Maximum number of requests performed at once (concurrency/threads has to fit in java int)");
+        options.addOption("th", "threads", true, "Number of worker threads to launch. If omitted defaults to number of cores JVM can see");
+
+        try {
+            CommandLineParser parser = new DefaultParser();
+            CommandLine cmd = parser.parse(options, args);
+
+            if(cmd.hasOption("dont-prepare")){
+                this.dont_prepare = true;
+            }
+
+            if(cmd.hasOption("nodes")){
+                String value = cmd.getOptionValue("nodes");
+                node_addresses = value.split(",");
+            }
+
+            if(cmd.hasOption("workload")){
+                String workloadValue = cmd.getOptionValue("workload");
+                this.workload = Workload.valueOf(workloadValue);
+            }
+
+            if(cmd.hasOption("tasks")){
+                this.tasks = Integer.parseInt(cmd.getOptionValue("tasks"));
+            }
+
+            if(cmd.hasOption("concurrency")){
+                this.concurrency = Integer.parseInt(cmd.getOptionValue("concurrency"));
+            }
+
+            if(cmd.hasOption("threads")){
+                this.threads = Integer.parseInt(cmd.getOptionValue("threads"));
+            }
+        } catch (ParseException e){
+            HelpFormatter helpFormatter = new HelpFormatter();
+            helpFormatter.printHelp("./run.sh [OPTION]...", options);
+            System.out.println();
+            System.out.println("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Config{" +
+                "node_addresses=" + Arrays.toString(node_addresses) +
+                ", workload=" + workload +
+                ", tasks=" + tasks +
+                ", concurrency=" + concurrency +
+                ", dont_prepare=" + dont_prepare +
+                ", threads=" + threads +
+                '}';
+    }
+}

--- a/benchmarks/basic/java-driver-3.x-async/source/src/main/java/MainClass.java
+++ b/benchmarks/basic/java-driver-3.x-async/source/src/main/java/MainClass.java
@@ -1,0 +1,174 @@
+import com.datastax.driver.core.*;
+import com.google.common.base.Function;
+import com.google.common.util.concurrent.AsyncFunction;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.ArrayList;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MainClass {
+
+    private static Cluster cluster;
+    private static Config config;
+
+    private static ExecutorService executor;
+    private static final String INSERT_STRING = "INSERT INTO benchks.benchtab (pk, v1, v2) VALUES(?, ?, ?)";
+    private static final String SELECT_STRING = "SELECT v1, v2 FROM benchks.benchtab WHERE pk = ?";
+
+    private static long benchmarkStart;
+
+    private static long benchmarkEnd;
+
+    public static void main(String[] args) throws InterruptedException, ExecutionException {
+
+        config = new Config(args);
+        System.out.println("Parsed config: ");
+        System.out.println(config.toString());
+
+        cluster = Cluster.builder().addContactPoints(config.node_addresses).withProtocolVersion(ProtocolVersion.V4).build();
+        cluster.getConfiguration().getPoolingOptions().setMaxQueueSize((int) Math.max(2048, 2 * config.concurrency));
+        Session session = cluster.connect();
+
+        prepareKeyspaceAndTable(session);
+
+        if (!config.dont_prepare) {
+            prepareKeyspaceAndTable(session);
+
+            if (config.workload.equals(Config.Workload.Selects)) {
+                prepareSelectsBenchmark(session);
+            }
+        }
+
+        AtomicLong requestsSent = new AtomicLong(0);
+
+        executor = Executors.newFixedThreadPool(config.threads);
+
+        System.out.println("Starting the benchmark");
+
+        benchmarkStart = System.nanoTime();
+        ArrayList<Future<?>> arr = new ArrayList<>();
+        for (int i = 0; i < config.threads; i++) {
+            arr.add(
+                    executor.submit(() -> {
+                        int permits = (int) (config.concurrency / config.threads);
+                        Semaphore semaphore = new Semaphore(permits);
+                        PreparedStatement insertQ = session.prepare(INSERT_STRING);
+                        PreparedStatement selectQ = session.prepare(SELECT_STRING);
+                        long pk;
+                        while ((pk = requestsSent.incrementAndGet()) < config.tasks) {
+                            try {
+                                semaphore.acquire();
+                            } catch (InterruptedException e) {
+                                throw new RuntimeException(e);
+                            }
+                            if (config.workload.equals(Config.Workload.Inserts) || config.workload.equals(Config.Workload.Mixed)) {
+                                ListenableFuture<ResultSet> resultSetA = session.executeAsync(insertQ.bind(pk, 2L * pk, 3L * pk));
+                                ListenableFuture<ResultSet> resultSetB;
+
+                                long finalPk = pk;
+                                if (config.workload.equals(Config.Workload.Selects) || config.workload.equals(Config.Workload.Mixed)) {
+                                    // Chain with select depending on workload
+                                    resultSetB = Futures.transform(resultSetA,
+                                            new AsyncFunction<ResultSet, ResultSet>() {
+                                                public ListenableFuture<ResultSet> apply(ResultSet rs) throws Exception {
+                                                    return session.executeAsync(selectQ.bind(finalPk));
+                                                }
+                                            });
+                                } else {
+                                    resultSetB = resultSetA;
+                                }
+                                ListenableFuture<Boolean> result;
+                                // Verify returned data depending on workload and return the permit
+                                if (config.workload.equals(Config.Workload.Selects) || config.workload.equals(Config.Workload.Mixed)) {
+                                    result = Futures.transform(resultSetB,
+                                            new Function<ResultSet, Boolean>() {
+                                                public Boolean apply(ResultSet rs) {
+                                                    semaphore.release();
+                                                    Row r = rs.one();
+                                                    if ((r.getLong("v1") != 2 * finalPk) || (r.getLong("v2") != 3 * finalPk)) {
+                                                        throw new RuntimeException(String.format("Received incorrect data. " + "Expected: (%s, %s, %s). " + "Received: (%s, %s ,%s).", finalPk, 2 * finalPk, 3 * finalPk, r.getInt("pk"), r.getInt("v1"), r.getInt("v2")));
+                                                    }
+                                                    return true;
+                                                }
+                                            });
+
+                                }
+                                else {
+                                    result = Futures.transform(resultSetB,
+                                            new Function<ResultSet, Boolean>() {
+                                                public Boolean apply(ResultSet rs) {
+                                                    semaphore.release();
+                                                    return true;
+                                                }
+                                            });
+                                }
+                            }
+                        }
+                        try {
+                            //possible only if all futures ended successfully
+                            semaphore.acquire(permits);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }));
+        }
+
+
+        executor.shutdown();
+        executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+        benchmarkEnd = System.nanoTime();
+        for (Future<?> f : arr) {
+            f.get(); // make sure nothing has thrown
+        }
+        System.out.println(String.format("Finished\nBenchmark time: %d ms\n", (benchmarkEnd - benchmarkStart) / 1_000_000));
+
+        session.close();
+        if (cluster != null) cluster.close();
+    }
+
+    static void prepareKeyspaceAndTable(Session session) {
+        session.execute("DROP KEYSPACE IF EXISTS benchks");
+        session.execute("CREATE KEYSPACE IF NOT EXISTS benchks WITH REPLICATION = {'class' " + ": 'SimpleStrategy', 'replication_factor' : 1}");
+        session.execute("CREATE TABLE IF NOT EXISTS benchks.benchtab (pk " + "bigint PRIMARY KEY, v1 bigint, v2 bigint)");
+        if (!cluster.getMetadata().checkSchemaAgreement()) {
+            throw new RuntimeException("Schema not in agreement after preparing keyspace and table.");
+        }
+    }
+
+    private static void prepareSelectsBenchmark(Session session) throws InterruptedException, ExecutionException {
+        System.out.println("Preparing a selects benchmark (inserting values)...");
+
+        AtomicLong nextBatchStart = new AtomicLong(0);
+        executor = Executors.newFixedThreadPool((int) config.threads);
+
+        ArrayList<Future<?>> arr = new ArrayList<>();
+        try {
+            for (int i = 0; i < config.concurrency; i++) {
+                arr.add(executor.submit(() -> {
+                    PreparedStatement insertQ = session.prepare(INSERT_STRING);
+                    while (true) {
+                        long curBatchStart = nextBatchStart.addAndGet(config.tasks / config.concurrency);
+                        if (curBatchStart >= config.tasks) {
+                            break;
+                        }
+                        long curBatchEnd = Math.min(curBatchStart + (config.tasks / config.concurrency), config.tasks);
+                        for (long pk = curBatchStart; pk < curBatchEnd; pk++) {
+                            session.execute(insertQ.bind(pk, 2L * pk, 3L * pk));
+                        }
+                    }
+                }));
+            }
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+            for (Future<?> f : arr) {
+                f.get(); // make sure nothing has thrown
+            }
+        }
+    }
+}
+
+

--- a/benchmarks/basic/java-driver-3.x/Dockerfile
+++ b/benchmarks/basic/java-driver-3.x/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+RUN apt update
+
+# Install java 8
+RUN apt install -y openjdk-8-jdk
+RUN apt install -y maven
+#RUN update-alternatives --set java /usr/lib/jvm/jdk1.8.0_version/bin/java
+RUN export JAVA_HOME=/usr/lib/jvm/jdk1.8.0_version
+
+# Copy benchmark code into the container
+COPY source /source
+WORKDIR /source
+
+# Compile the code
+RUN mvn clean package

--- a/benchmarks/basic/java-driver-3.x/build.sh
+++ b/benchmarks/basic/java-driver-3.x/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build . -t rust-driver-benchmarks-basic-java-driver-3.x

--- a/benchmarks/basic/java-driver-3.x/run.sh
+++ b/benchmarks/basic/java-driver-3.x/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker run --rm -it --network host rust-driver-benchmarks-basic-java-driver-3.x \
+java -cp /source/target/source-1.0-SNAPSHOT.jar MainClass "$@"

--- a/benchmarks/basic/java-driver-3.x/source/pom.xml
+++ b/benchmarks/basic/java-driver-3.x/source/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>source</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.5.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.scylladb</groupId>
+            <artifactId>scylla-driver-core</artifactId>
+            <version>3.11.2.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+
+</project>

--- a/benchmarks/basic/java-driver-3.x/source/src/main/java/Config.java
+++ b/benchmarks/basic/java-driver-3.x/source/src/main/java/Config.java
@@ -1,0 +1,88 @@
+import java.util.Arrays;
+
+import org.apache.commons.cli.*;
+
+import static java.lang.Math.max;
+
+class Config{
+
+    enum Workload {
+        Inserts,
+        Selects,
+        Mixed,
+    };
+
+    String[] node_addresses;
+    Workload workload;
+    long tasks;
+    long concurrency;
+    long batch_size;
+    boolean dont_prepare;
+
+    Config(String[] args)  {
+
+        this.node_addresses = new String[]{"127.0.0.1"};
+        this.workload = Workload.Inserts;
+        this.tasks = 1000 * 1000;
+        this.concurrency = 1024;
+        this.dont_prepare = false;
+
+        Options options = new Options();
+
+        options.addOption("d", "dont-prepare", false, "Don't create tables and insert into them before the benchmark");
+        options.addOption("n", "nodes", true, "Addresses of database nodes to connect to separated by a comma");
+        options.addOption("w", "workload", true, "Type of work to perform (Inserts, Selects, Mixed)");
+        options.addOption("t", "tasks", true, "Total number of tasks (requests) to perform the during benchmark. In case of mixed workload there will be tasks inserts and tasks selects");
+        options.addOption("c", "concurrency", true, "Maximum number of requests performed at once");
+
+        try {
+            CommandLineParser parser = new DefaultParser();
+            CommandLine cmd = parser.parse(options, args);
+
+            if(cmd.hasOption("dont-prepare")){
+                this.dont_prepare = true;
+            }
+
+            if(cmd.hasOption("nodes")){
+                String value = cmd.getOptionValue("nodes");
+                node_addresses = value.split(",");
+            }
+
+            if(cmd.hasOption("workload")){
+                String workloadValue = cmd.getOptionValue("workload");
+                this.workload = Workload.valueOf(workloadValue);
+            }
+
+            if(cmd.hasOption("tasks")){
+                this.tasks = Integer.parseInt(cmd.getOptionValue("tasks"));
+            }
+
+            if(cmd.hasOption("concurrency")){
+                this.concurrency = Integer.parseInt(cmd.getOptionValue("concurrency"));
+            }
+        } catch (ParseException e){
+            HelpFormatter helpFormatter = new HelpFormatter();
+            helpFormatter.printHelp("./run.sh [OPTION]...", options);
+            System.out.println();
+            System.out.println("Unexpected exception: " + e.getMessage());
+        }
+
+        batch_size = 256;
+
+        if (this.tasks/this.batch_size < this.concurrency) {
+            this.batch_size = max(1, this.tasks / this.concurrency);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Config{" +
+                "node_addresses=" + Arrays.toString(node_addresses) +
+                ", workload=" + workload +
+                ", tasks=" + tasks +
+                ", concurrency=" + concurrency +
+                ", batch_size=" + batch_size +
+                ", dont_prepare=" + dont_prepare +
+                '}';
+    }
+}

--- a/benchmarks/basic/java-driver-3.x/source/src/main/java/MainClass.java
+++ b/benchmarks/basic/java-driver-3.x/source/src/main/java/MainClass.java
@@ -1,0 +1,134 @@
+import com.datastax.driver.core.*;
+
+import java.util.ArrayList;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MainClass {
+
+    private static Cluster cluster;
+    private static Config config;
+
+    private static ExecutorService executor;
+    private static final String INSERT_STRING = "INSERT INTO benchks.benchtab (pk, v1, v2) VALUES(?, ?, ?)";
+    private static final String SELECT_STRING = "SELECT v1, v2 FROM benchks.benchtab WHERE pk = ?";
+
+    private static long benchmarkStart;
+
+    private static long benchmarkEnd;
+
+    public static void main(String[] args) throws InterruptedException, ExecutionException {
+
+        config = new Config(args);
+        System.out.println("Parsed config: ");
+        System.out.println(config.toString());
+
+        cluster = Cluster.builder().addContactPoints(config.node_addresses).withProtocolVersion(ProtocolVersion.V4).build();
+        cluster.getConfiguration().getPoolingOptions().setMaxQueueSize((int) Math.max(2048, 2 * config.concurrency));
+        Session session = cluster.connect();
+
+        prepareKeyspaceAndTable(session);
+
+        if (!config.dont_prepare) {
+            prepareKeyspaceAndTable(session);
+
+            if (config.workload.equals(Config.Workload.Selects)) {
+                prepareSelectsBenchmark(session);
+            }
+        }
+
+        AtomicLong nextBatchStart = new AtomicLong(0);
+
+        executor = Executors.newFixedThreadPool((int) config.concurrency);
+
+        System.out.println("Starting the benchmark");
+
+        benchmarkStart = System.nanoTime();
+        ArrayList<Future<?>> arr = new ArrayList<>();
+        for (int i = 0; i < config.concurrency; i++) {
+            arr.add(
+                    executor.submit(() -> {
+                        PreparedStatement insertQ = session.prepare(INSERT_STRING);
+                        PreparedStatement selectQ = session.prepare(SELECT_STRING);
+                        while (true) {
+
+                            long curBatchStart = nextBatchStart.addAndGet(config.batch_size);
+                            if (curBatchStart >= config.tasks) {
+                                break;
+                            }
+
+                            long curBatchEnd = Math.min(curBatchStart + config.batch_size, config.tasks);
+
+                            for (long pk = curBatchStart; pk < curBatchEnd; pk++) {
+                                if (config.workload.equals(Config.Workload.Inserts) || config.workload.equals(Config.Workload.Mixed)) {
+                                    session.execute(insertQ.bind(pk, 2L * pk, 3L * pk));
+                                }
+
+                                if (config.workload.equals(Config.Workload.Selects) || config.workload.equals(Config.Workload.Mixed)) {
+                                    ResultSet rs = session.execute(selectQ.bind(pk));
+                                    Row r = rs.one();
+                                    if ((r.getLong("v1") != 2 * pk) || (r.getLong("v2") != 3 * pk)) {
+                                        throw new RuntimeException(String.format("Received incorrect data. " + "Expected: (%s, %s, %s). " + "Received: (%s, %s ,%s).", pk, 2 * pk, 3 * pk, r.getInt("pk"), r.getInt("v1"), r.getInt("v2")));
+                                    }
+                                }
+                            }
+                        }
+                    }));
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+        benchmarkEnd = System.nanoTime();
+        for (Future<?> f : arr) {
+            f.get(); // make sure nothing has thrown
+        }
+        System.out.println(String.format("Finished\nBenchmark time: %d ms\n", (benchmarkEnd - benchmarkStart) / 1_000_000));
+
+        session.close();
+        if (cluster != null) cluster.close();
+    }
+
+    static void prepareKeyspaceAndTable(Session session) {
+        session.execute("DROP KEYSPACE IF EXISTS benchks");
+        session.execute("CREATE KEYSPACE IF NOT EXISTS benchks WITH REPLICATION = {'class' " + ": 'SimpleStrategy', 'replication_factor' : 1}");
+        session.execute("CREATE TABLE IF NOT EXISTS benchks.benchtab (pk " + "bigint PRIMARY KEY, v1 bigint, v2 bigint)");
+        if (!cluster.getMetadata().checkSchemaAgreement()) {
+            throw new RuntimeException("Schema not in agreement after preparing keyspace and table.");
+        }
+    }
+
+    private static void prepareSelectsBenchmark(Session session) throws InterruptedException, ExecutionException {
+        System.out.println("Preparing a selects benchmark (inserting values)...");
+
+        AtomicLong nextBatchStart = new AtomicLong(0);
+        executor = Executors.newFixedThreadPool((int) config.concurrency);
+
+        ArrayList<Future<?>> arr = new ArrayList<>();
+        try {
+            for (int i = 0; i < config.concurrency; i++) {
+                arr.add(executor.submit(() -> {
+                    PreparedStatement insertQ = session.prepare(INSERT_STRING);
+                    while (true) {
+                        long curBatchStart = nextBatchStart.addAndGet(config.batch_size);
+                        if (curBatchStart >= config.tasks) {
+                            break;
+                        }
+                        long curBatchEnd = Math.min(curBatchStart + config.batch_size, config.tasks);
+                        for (long pk = curBatchStart; pk < curBatchEnd; pk++) {
+                            session.execute(insertQ.bind(pk, 2L * pk, 3L * pk));
+                        }
+                    }
+                }));
+            }
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+            for (Future<?> f : arr) {
+                f.get(); // make sure nothing has thrown
+            }
+        }
+    }
+
+}
+
+

--- a/benchmarks/basic/java-driver-4.x/Dockerfile
+++ b/benchmarks/basic/java-driver-4.x/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+RUN apt update
+
+# Install java 8
+RUN apt install -y openjdk-8-jdk
+RUN apt install -y maven
+#RUN update-alternatives --set java /usr/lib/jvm/jdk1.8.0_version/bin/java
+RUN export JAVA_HOME=/usr/lib/jvm/jdk1.8.0_version
+
+# Copy benchmark code into the container
+COPY source /source
+WORKDIR /source
+
+# Compile the code
+RUN mvn clean package

--- a/benchmarks/basic/java-driver-4.x/build.sh
+++ b/benchmarks/basic/java-driver-4.x/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build . -t rust-driver-benchmarks-basic-java-driver-4.x

--- a/benchmarks/basic/java-driver-4.x/run.sh
+++ b/benchmarks/basic/java-driver-4.x/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker run --rm -it --network host rust-driver-benchmarks-basic-java-driver-4.x \
+java -cp /source/target/source-1.0-SNAPSHOT.jar MainClass "$@"

--- a/benchmarks/basic/java-driver-4.x/source/pom.xml
+++ b/benchmarks/basic/java-driver-4.x/source/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>source</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <driver.version>4.14.1.0</driver.version>
+    </properties>
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.5.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.scylladb</groupId>
+            <artifactId>java-driver-core</artifactId>
+            <version>${driver.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.scylladb</groupId>
+            <artifactId>java-driver-query-builder</artifactId>
+            <version>${driver.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.scylladb</groupId>
+            <artifactId>java-driver-mapper-runtime</artifactId>
+            <version>${driver.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+
+</project>

--- a/benchmarks/basic/java-driver-4.x/source/src/main/java/Config.java
+++ b/benchmarks/basic/java-driver-4.x/source/src/main/java/Config.java
@@ -1,0 +1,88 @@
+import java.util.Arrays;
+
+import org.apache.commons.cli.*;
+
+import static java.lang.Math.max;
+
+class Config{
+
+    enum Workload {
+        Inserts,
+        Selects,
+        Mixed,
+    };
+
+    String[] node_addresses;
+    Workload workload;
+    long tasks;
+    long concurrency;
+    long batch_size;
+    boolean dont_prepare;
+
+    Config(String[] args)  {
+
+        this.node_addresses = new String[]{"127.0.0.1"};
+        this.workload = Workload.Inserts;
+        this.tasks = 1000 * 1000;
+        this.concurrency = 1024;
+        this.dont_prepare = false;
+
+        Options options = new Options();
+
+        options.addOption("d", "dont-prepare", false, "Don't create tables and insert into them before the benchmark");
+        options.addOption("n", "nodes", true, "Addresses of database nodes to connect to separated by a comma");
+        options.addOption("w", "workload", true, "Type of work to perform (Inserts, Selects, Mixed)");
+        options.addOption("t", "tasks", true, "Total number of tasks (requests) to perform the during benchmark. In case of mixed workload there will be tasks inserts and tasks selects");
+        options.addOption("c", "concurrency", true, "Maximum number of requests performed at once");
+
+        try {
+            CommandLineParser parser = new DefaultParser();
+            CommandLine cmd = parser.parse(options, args);
+
+            if(cmd.hasOption("dont-prepare")){
+                this.dont_prepare = true;
+            }
+
+            if(cmd.hasOption("nodes")){
+                String value = cmd.getOptionValue("nodes");
+                node_addresses = value.split(",");
+            }
+
+            if(cmd.hasOption("workload")){
+                String workloadValue = cmd.getOptionValue("workload");
+                this.workload = Workload.valueOf(workloadValue);
+            }
+
+            if(cmd.hasOption("tasks")){
+                this.tasks = Integer.parseInt(cmd.getOptionValue("tasks"));
+            }
+
+            if(cmd.hasOption("concurrency")){
+                this.concurrency = Integer.parseInt(cmd.getOptionValue("concurrency"));
+            }
+        } catch (ParseException e){
+            HelpFormatter helpFormatter = new HelpFormatter();
+        helpFormatter.printHelp("./run.sh [OPTION]...", options);
+            System.out.println();
+            System.out.println("Unexpected exception: " + e.getMessage());
+        }
+
+        batch_size = 256;
+
+        if (this.tasks/this.batch_size < this.concurrency) {
+            this.batch_size = max(1, this.tasks / this.concurrency);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Config{" +
+                "node_addresses=" + Arrays.toString(node_addresses) +
+                ", workload=" + workload +
+                ", tasks=" + tasks +
+                ", concurrency=" + concurrency +
+                ", batch_size=" + batch_size +
+                ", dont_prepare=" + dont_prepare +
+                '}';
+    }
+}

--- a/benchmarks/basic/java-driver-4.x/source/src/main/java/MainClass.java
+++ b/benchmarks/basic/java-driver-4.x/source/src/main/java/MainClass.java
@@ -1,0 +1,163 @@
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MainClass {
+    private static Config config;
+
+    private static ExecutorService executor;
+    private static final String INSERT_STRING = "INSERT INTO benchks.benchtab (pk, v1, v2) VALUES(?, ?, ?)";
+    private static final String SELECT_STRING = "SELECT v1, v2 FROM benchks.benchtab WHERE pk = ?";
+
+    private static long benchmarkStart;
+
+    private static long benchmarkEnd;
+
+    public static void main(String[] args) throws InterruptedException, ExecutionException {
+
+        config = new Config(args);
+        System.out.println("Parsed config: ");
+        System.out.println(config.toString());
+
+        DriverConfigLoader loader =
+                DriverConfigLoader.programmaticBuilder()
+                        .withString(DefaultDriverOption.PROTOCOL_VERSION, "V4")
+                        .withLong(DefaultDriverOption.REQUEST_THROTTLER_MAX_QUEUE_SIZE, Math.max(2048, 2L * config.concurrency))
+                        .build();
+
+        CqlSession session = CqlSession
+                .builder()
+                .withConfigLoader(loader)
+                .addContactPoints(parseAddresses(config.node_addresses))
+                .withLocalDatacenter("datacenter1")
+                .build();
+
+        prepareKeyspaceAndTable(session);
+
+        if (!config.dont_prepare) {
+            prepareKeyspaceAndTable(session);
+
+            if (config.workload.equals(Config.Workload.Selects)) {
+                prepareSelectsBenchmark(session);
+            }
+        }
+
+        AtomicLong nextBatchStart = new AtomicLong(0);
+
+        executor = Executors.newFixedThreadPool((int) config.concurrency);
+
+        System.out.println("Starting the benchmark");
+
+        benchmarkStart = System.nanoTime();
+        ArrayList<Future<?>> arr = new ArrayList<>();
+        for (int i = 0; i < config.concurrency; i++) {
+            arr.add(
+                    executor.submit(() -> {
+                        PreparedStatement insertQ = session.prepare(INSERT_STRING);
+                        PreparedStatement selectQ = session.prepare(SELECT_STRING);
+                        while (true) {
+
+                            long curBatchStart = nextBatchStart.addAndGet(config.batch_size);
+                            if (curBatchStart >= config.tasks) {
+                                break;
+                            }
+
+                            long curBatchEnd = Math.min(curBatchStart + config.batch_size, config.tasks);
+
+                            for (long pk = curBatchStart; pk < curBatchEnd; pk++) {
+                                if (config.workload.equals(Config.Workload.Inserts) || config.workload.equals(Config.Workload.Mixed)) {
+                                    session.execute(insertQ.bind(pk, 2L * pk, 3L * pk));
+                                }
+
+                                if (config.workload.equals(Config.Workload.Selects) || config.workload.equals(Config.Workload.Mixed)) {
+                                    ResultSet rs = session.execute(selectQ.bind(pk));
+                                    Row r = rs.one();
+                                    assert r != null;
+                                    if ((r.getLong("v1") != 2 * pk) || (r.getLong("v2") != 3 * pk)) {
+                                        throw new RuntimeException(String.format("Received incorrect data. " + "Expected: (%s, %s, %s). " + "Received: (%s, %s ,%s).", pk, 2 * pk, 3 * pk, r.getInt("pk"), r.getInt("v1"), r.getInt("v2")));
+                                    }
+                                }
+                            }
+                        }
+                    }));
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+        benchmarkEnd = System.nanoTime();
+        for (Future<?> f : arr) {
+            f.get(); // make sure nothing has thrown
+        }
+        System.out.println(String.format("Finished\nBenchmark time: %d ms\n", (benchmarkEnd - benchmarkStart) / 1_000_000));
+
+        session.close();
+    }
+
+    static void prepareKeyspaceAndTable(CqlSession session) {
+        session.execute("DROP KEYSPACE IF EXISTS benchks");
+        session.execute("CREATE KEYSPACE IF NOT EXISTS benchks WITH REPLICATION = {'class' " + ": 'SimpleStrategy', 'replication_factor' : 1}");
+        session.execute("CREATE TABLE IF NOT EXISTS benchks.benchtab (pk " + "bigint PRIMARY KEY, v1 bigint, v2 bigint)");
+        if (!session.checkSchemaAgreement()) {
+            throw new RuntimeException("Schema not in agreement after preparing keyspace and table.");
+        }
+    }
+
+    private static void prepareSelectsBenchmark(CqlSession session) throws InterruptedException, ExecutionException {
+        System.out.println("Preparing a selects benchmark (inserting values)...");
+
+        AtomicLong nextBatchStart = new AtomicLong(0);
+        executor = Executors.newFixedThreadPool((int) config.concurrency);
+
+        ArrayList<Future<?>> arr = new ArrayList<>();
+        try {
+            for (int i = 0; i < config.concurrency; i++) {
+                arr.add(executor.submit(() -> {
+                    PreparedStatement insertQ = session.prepare(INSERT_STRING);
+                    while (true) {
+                        long curBatchStart = nextBatchStart.addAndGet(config.batch_size);
+                        if (curBatchStart >= config.tasks) {
+                            break;
+                        }
+                        long curBatchEnd = Math.min(curBatchStart + config.batch_size, config.tasks);
+                        for (long pk = curBatchStart; pk < curBatchEnd; pk++) {
+                            session.execute(insertQ.bind(pk, 2L * pk, 3L * pk));
+                        }
+                    }
+                }));
+            }
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+            for (Future<?> f : arr) {
+                f.get(); // make sure nothing has thrown
+            }
+        }
+    }
+
+    private static List<InetSocketAddress> parseAddresses(String[] arr){
+        ArrayList<InetSocketAddress> result = new ArrayList<>();
+        for(String s : arr){
+            InetSocketAddress addr;
+            if(s.contains(":")){
+                String[] tmp = s.split(":");
+                addr = new InetSocketAddress(tmp[0], Integer.parseInt(tmp[1]));
+            }
+            else {
+                addr = new InetSocketAddress(s, 9042);
+            }
+            result.add(addr);
+        }
+        return result;
+    }
+}
+
+


### PR DESCRIPTION
Adds 3 separate java-driver benchmarks. 

Java-driver-3.x and java-driver-4.x benchmarks were inspired by gocql and cpp implementations.
They use multiple threads with blocking `execute` calls. The intent was to make them similar enough to other implementations thus more comparable with them.

Java-driver-3.x-async has been modified to run async executes with smaller number of threads. It also accepts additional `-threads <arg>` parameter that allows to specify how many worker threads to use. It will still adhere to sending at most `concurrency` requests at the same time.